### PR TITLE
Render all docs/ files as GitHub Pages documentation pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "site/**"
+      - "docs/**"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -27,6 +28,9 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+
+      - name: Import docs/ into the site
+        run: bash site/scripts/import-docs.sh docs site/docs
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,10 @@ flake.lock.rej
 # hosts/local-*/
 # overlays/local/
 # pkgs/local/
+
+# Jekyll Pages site build artifacts and generated docs pages
+site/docs/
+site/_site/
+site/.jekyll-cache/
+site/.jekyll-metadata
+site/Gemfile.lock

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -25,6 +25,8 @@ nav:
     url: /getting-started/
   - title: "Features"
     url: /features/
+  - title: "Documentation"
+    url: /documentation/
 
 # Source repository
 github_repo: "https://github.com/olafkfreund/nixos-template"
@@ -44,3 +46,4 @@ exclude:
   - Gemfile.lock
   - node_modules/
   - vendor/
+  - scripts/

--- a/site/documentation.md
+++ b/site/documentation.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: "Documentation"
+permalink: /documentation/
+---
+
+```
+$ ls docs/
+```
+
+Every guide from the repository's `docs/` folder, rendered here as a page.
+Source of truth lives in [`docs/`](https://github.com/olafkfreund/nixos-template/tree/main/docs) — these pages are generated from it on every deploy.
+
+{% assign doc_pages = site.pages | where_exp: "p", "p.url contains '/docs/'" | sort: "title" %}
+
+**{{ doc_pages | size }} documents**
+
+{% for d in doc_pages %}
+- [{{ d.title }}]({{ d.url | relative_url }})
+{% endfor %}
+
+---
+
+Looking for something specific? Use your browser's find (Ctrl/Cmd-F), or browse the
+[full source on GitHub](https://github.com/olafkfreund/nixos-template/tree/main/docs).

--- a/site/scripts/import-docs.sh
+++ b/site/scripts/import-docs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Import every Markdown file from the repository docs/ folder into the Jekyll
+# site as a styled page. Runs at build time (in CI) so docs/ stays the single
+# source of truth — generated pages are NOT committed.
+#
+# Usage: site/scripts/import-docs.sh <src-docs-dir> <dest-dir>
+#   e.g. site/scripts/import-docs.sh docs site/docs
+#
+# For each docs/NAME.md it writes dest/NAME.md with:
+#   - Jekyll front matter (layout: page, title from the first H1, stable permalink)
+#   - the body wrapped in {% raw %}..{% endraw %} so literal Liquid-looking text
+#     (e.g. GitHub Actions ${{ ... }} expressions) is never interpreted
+#   - intra-doc links rewritten from *.md to *.html so they resolve between pages
+
+set -euo pipefail
+
+SRC="${1:-docs}"
+DEST="${2:-site/docs}"
+
+if [ ! -d "$SRC" ]; then
+  echo "import-docs: source dir '$SRC' not found" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+count=0
+
+for f in "$SRC"/*.md; do
+  [ -e "$f" ] || continue
+  base="$(basename "$f" .md)"
+
+  # Skip the docs index itself — the site has its own /documentation/ listing.
+  if [ "$base" = "README" ]; then
+    continue
+  fi
+
+  # Title: first level-1 heading, else the file name.
+  title="$(grep -m1 '^# ' "$f" 2>/dev/null | sed 's/^# *//' | tr -d '"' || true)"
+  if [ -z "$title" ]; then
+    title="$base"
+  fi
+
+  out="$DEST/$base.md"
+  {
+    printf -- '---\n'
+    printf 'layout: page\n'
+    printf 'title: "%s"\n' "$title"
+    printf 'permalink: /docs/%s.html\n' "$base"
+    printf -- '---\n'
+    printf '{%% raw %%}\n'
+    # Rewrite links:
+    #  - ../PATH (escapes docs/) -> GitHub blob URL so it still resolves
+    #  - between docs: (X.md) / (./X.md) / (docs/X.md) -> (X.html); keep #anchor
+    sed -E \
+      -e 's@\]\(\.\./([A-Za-z0-9._/-]+)\)@](https://github.com/olafkfreund/nixos-template/blob/main/\1)@g' \
+      -e 's@\]\(\./([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
+      -e 's@\]\(docs/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
+      -e 's@\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
+      "$f"
+    printf '\n{%% endraw %%}\n'
+  } > "$out"
+
+  count=$((count + 1))
+done
+
+echo "import-docs: generated $count doc page(s) in $DEST"


### PR DESCRIPTION
## Summary

Implements every `docs/*.md` guide as a page on the GitHub Pages site, with a **Documentation** nav entry and an auto-generated index. `docs/` remains the single source of truth — pages are generated at build time, **not** committed (no duplication).

## How it works
- **`site/scripts/import-docs.sh`** (runs in the Pages workflow before the Jekyll build): copies `docs/*.md` → `site/docs/*.md`, adding Jekyll front matter (`layout: page`, title from the first `# H1`, stable `/docs/NAME.html` permalink). It wraps each body in `{% raw %}` so literal `${{ }}`-style text can never break Liquid, rewrites inter-doc `.md` links to `.html`, and rewrites `../` links (e.g. `../CLAUDE.md`) to GitHub blob URLs. The `docs/README` index is skipped.
- **`site/documentation.md`** → `/documentation/`: auto-lists every generated doc via Liquid, so new docs appear with zero manual upkeep. Currently surfaces **28 documents**.
- **`_config.yml`**: adds *Documentation* to the nav; excludes `scripts/` from the build.
- **`pages.yml`**: runs the importer before `jekyll-build-pages`; also redeploys when `docs/**` changes.
- **`.gitignore`**: ignores generated `site/docs/` and Jekyll build artifacts.

## Validation
- Importer run locally over all 29 docs → 28 pages generated, all inter-doc `.md` links rewritten, `../` links converted to blob URLs, `shellcheck` clean.
- `pages.yml` and `_config.yml` validated as YAML.

Live site after merge: https://olafkfreund.github.io/nixos-template/documentation/

🤖 Generated with [Claude Code](https://claude.com/claude-code)