### PR TITLE
Add left-sidebar dark layout (replace remote theme nav blob)

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
+# Local dev parity with the GitHub Pages build. The site is self-contained
+# (custom layouts in _layouts/ + assets/css/style.css), no remote theme.
 gem "github-pages", group: :jekyll_plugins
-gem "jekyll-remote-theme"

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -7,15 +7,10 @@ baseurl: "/nixos-template"
 author:
   name: "olafkfreund"
 
-remote_theme: b2a3e8/jekyll-theme-console
-
-plugins:
-  - jekyll-remote-theme
-  - jekyll-seo-tag
-
-# jekyll-theme-console options
-style: dark
-show_excerpts: false
+# Self-contained dark "console" layout with a left sidebar (site/_layouts +
+# site/assets/css/style.css). No remote theme — that one dumped every page into
+# a single centered top nav.
+plugins: []
 
 # Navigation
 nav:

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title and page.layout != "home" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}">{% endif %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
+  <label for="nav-toggle" class="nav-toggle-btn" aria-label="Toggle navigation">&#9776; menu</label>
+
+  <aside class="sidebar">
+    <div class="brand">
+      <a href="{{ '/' | relative_url }}" class="brand-name">{{ site.title }}</a>
+      {% if site.tagline %}<p class="brand-tag">{{ site.tagline }}</p>{% endif %}
+    </div>
+
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-list">
+        {% for item in site.nav %}
+        <li><a href="{{ item.url | relative_url }}"{% if page.url == item.url %} class="active" aria-current="page"{% endif %}>{{ item.title }}</a></li>
+        {% endfor %}
+      </ul>
+
+      <p class="nav-heading">Documentation</p>
+      <ul class="nav-list nav-docs">
+        {% assign doc_pages = site.pages | where_exp: "p", "p.url contains '/docs/'" | sort: "title" %}
+        {% for d in doc_pages %}
+        <li><a href="{{ d.url | relative_url }}"{% if page.url == d.url %} class="active" aria-current="page"{% endif %}>{{ d.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+
+    <div class="sidebar-foot">
+      <a href="{{ site.github_repo }}">&#9733; GitHub</a>
+    </div>
+  </aside>
+
+  <main class="content">
+    <article class="prose">
+      {% if page.title and page.layout != "home" %}<h1 class="page-title">{{ page.title }}</h1>{% endif %}
+      {{ content }}
+    </article>
+    <footer class="site-foot">
+      <span>{{ site.title }}</span>
+      <span>&middot;</span>
+      <a href="{{ site.github_repo }}">Source on GitHub</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/site/_layouts/home.html
+++ b/site/_layouts/home.html
@@ -1,0 +1,4 @@
+---
+layout: default
+---
+{{ content }}

--- a/site/_layouts/page.html
+++ b/site/_layouts/page.html
@@ -1,0 +1,4 @@
+---
+layout: default
+---
+{{ content }}

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1,0 +1,210 @@
+/* NixOS Template — dark "console" theme with a fixed left sidebar */
+
+:root {
+  --bg:        #0b0e14;
+  --bg-side:   #0d1117;
+  --bg-code:   #11161f;
+  --border:    #1f2733;
+  --fg:        #c9d1d9;
+  --muted:     #8b949e;
+  --accent:    #7ee787; /* terminal green */
+  --accent-dim:#3fb950;
+  --link:      #79c0ff;
+  --sidebar-w: 280px;
+  --maxw:      900px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, "Source Code Pro", Menlo, Consolas, monospace;
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  width: var(--sidebar-w);
+  background: var(--bg-side);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 1.5rem 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.brand { padding: 0 0.5rem 1rem; border-bottom: 1px solid var(--border); margin-bottom: 1rem; }
+.brand-name {
+  display: block;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+}
+.brand-name::before { content: "❯ "; color: var(--accent-dim); }
+.brand-tag {
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin: 0.4rem 0 0;
+  word-break: break-word;
+}
+
+.nav { flex: 1; }
+.nav-heading {
+  color: var(--accent-dim);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  margin: 1.4rem 0.5rem 0.4rem;
+}
+.nav-list { list-style: none; margin: 0; padding: 0; }
+.nav-list li { margin: 0; }
+.nav-list a {
+  display: block;
+  color: var(--fg);
+  padding: 0.32rem 0.55rem;
+  border-radius: 5px;
+  border-left: 2px solid transparent;
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+.nav-list a:hover { background: rgba(126, 231, 135, 0.08); text-decoration: none; color: var(--accent); }
+.nav-list a.active {
+  background: rgba(126, 231, 135, 0.12);
+  border-left-color: var(--accent);
+  color: var(--accent);
+  font-weight: 500;
+}
+.nav-docs a { color: var(--muted); }
+.nav-docs a:hover, .nav-docs a.active { color: var(--accent); }
+
+.sidebar-foot {
+  margin-top: 1.2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.82rem;
+}
+
+/* ---------- Content ---------- */
+.content {
+  margin-left: var(--sidebar-w);
+  padding: 2.5rem 3rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.prose { max-width: var(--maxw); width: 100%; flex: 1; }
+
+.page-title {
+  color: var(--accent);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.4rem;
+  margin-top: 0;
+}
+
+.prose h1, .prose h2, .prose h3, .prose h4 { color: #e6edf3; line-height: 1.3; margin-top: 1.8rem; }
+.prose h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; }
+.prose h1 { color: var(--accent); }
+.prose p, .prose li { color: var(--fg); }
+.prose strong { color: #e6edf3; }
+.prose hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+.prose blockquote {
+  margin: 1rem 0;
+  padding: 0.2rem 1rem;
+  border-left: 3px solid var(--accent-dim);
+  background: rgba(126, 231, 135, 0.05);
+  color: var(--muted);
+}
+
+/* Inline + block code */
+code {
+  font-family: inherit;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.85em;
+  color: var(--accent);
+}
+pre {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+pre code { background: none; border: none; padding: 0; color: var(--fg); font-size: 0.85rem; }
+.highlight { margin: 1rem 0; }
+.highlight pre { margin: 0; }
+
+/* Tables */
+.prose table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.85rem; display: block; overflow-x: auto; }
+.prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
+.prose th { background: var(--bg-code); color: var(--accent); }
+.prose tr:nth-child(even) td { background: rgba(255,255,255,0.02); }
+
+.prose img { max-width: 100%; }
+
+.site-foot {
+  margin-top: 3rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.8rem;
+  display: flex;
+  gap: 0.6rem;
+  max-width: var(--maxw);
+}
+
+/* ---------- Mobile / hamburger ---------- */
+.nav-toggle-btn {
+  display: none;
+  position: fixed;
+  top: 0.8rem; right: 0.8rem;
+  z-index: 30;
+  background: var(--bg-code);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .nav-toggle-btn { display: inline-block; }
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 20;
+    box-shadow: 2px 0 20px rgba(0,0,0,0.5);
+  }
+  .nav-toggle:checked ~ .sidebar { transform: translateX(0); }
+  .content { margin-left: 0; padding: 4rem 1.25rem 2rem; }
+}
+
+/* ---------- Minimal Rouge syntax colors (dark) ---------- */
+.highlight .c, .highlight .c1, .highlight .cm, .highlight .cd { color: #6a737d; font-style: italic; }
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kr { color: #ff7b72; }
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .se { color: #a5d6ff; }
+.highlight .nb, .highlight .bp { color: #79c0ff; }
+.highlight .nf, .highlight .nx { color: #d2a8ff; }
+.highlight .mi, .highlight .mf, .highlight .il { color: #79c0ff; }
+.highlight .o, .highlight .ow { color: #ff7b72; }
+.highlight .nt { color: #7ee787; }
+.highlight .na { color: #79c0ff; }
+.highlight .gp { color: var(--accent-dim); }

--- a/site/scripts/import-docs.sh
+++ b/site/scripts/import-docs.sh
@@ -48,15 +48,14 @@ for f in "$SRC"/*.md; do
     printf 'permalink: /docs/%s.html\n' "$base"
     printf -- '---\n'
     printf '{%% raw %%}\n'
-    # Rewrite links:
+    # Drop the first H1 (the layout already renders the title), then rewrite links:
     #  - ../PATH (escapes docs/) -> GitHub blob URL so it still resolves
     #  - between docs: (X.md) / (./X.md) / (docs/X.md) -> (X.html); keep #anchor
-    sed -E \
+    awk 'BEGIN{dropped=0} /^# /&&!dropped{dropped=1;next} {print}' "$f" | sed -E \
       -e 's@\]\(\.\./([A-Za-z0-9._/-]+)\)@](https://github.com/olafkfreund/nixos-template/blob/main/\1)@g' \
       -e 's@\]\(\./([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
       -e 's@\]\(docs/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
-      -e 's@\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
-      "$f"
+      -e 's@\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g'
     printf '\n{%% endraw %%}\n'
   } > "$out"
 


### PR DESCRIPTION
## Problem
The `jekyll-theme-console` remote theme rendered **every** page — including all 28 imported doc pages — as a single centered top-nav blob (see prior screenshot). No sidebar, unreadable.

## Fix
Replace the remote theme with a **self-contained dark "console" layout that has a proper fixed left sidebar**.

- `site/_layouts/default.html` — sidebar (brand + tagline, primary nav, auto-listed Documentation links with active-state highlighting) + content + footer.
- `site/_layouts/{page,home}.html` — thin wrappers over `default`.
- `site/assets/css/style.css` — dark terminal palette, JetBrains Mono, fixed scrollable sidebar, active links, responsive off-canvas drawer (<900px), styled code/tables/blockquotes, minimal Rouge dark syntax colors.
- `_config.yml` — remove `remote_theme` + plugins (self-contained now).
- `import-docs.sh` — strip each doc's first H1 (the layout renders the title) to avoid duplicated headings.
- `Gemfile` — drop `jekyll-remote-theme`.

## Verification
Built locally with Jekyll and screenshotted the home page and doc pages: the left sidebar, grouped nav, active-link highlighting, and Nix syntax highlighting all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)