### PR TITLE
Fix nav 404s (/getting-started/, /features/) and repair all internal links

### DIFF
--- a/docs/ZERO-CONFIGURATION.md
+++ b/docs/ZERO-CONFIGURATION.md
@@ -306,4 +306,4 @@ The zero-configuration approach makes NixOS accessible to users without deep har
 
 - [Hardware Auto-Optimization Guide](./HARDWARE-AUTO-OPTIMIZATION.md) - Detailed technical documentation
 - [System Identification Guide](./SYSTEM-IDENTIFICATION.md) - System metadata and naming
-- [Profile System Guide](./PROFILE-SYSTEM.md) - Home Manager profile architecture
+- [Home Manager profiles](https://github.com/olafkfreund/nixos-template/tree/main/home/profiles) - Home Manager profile architecture

--- a/site/features.md
+++ b/site/features.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: "Features"
+permalink: /features/
 ---
 
 ```

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: "Getting Started"
+permalink: /getting-started/
 ---
 
 ```

--- a/site/scripts/import-docs.sh
+++ b/site/scripts/import-docs.sh
@@ -48,14 +48,11 @@ for f in "$SRC"/*.md; do
     printf 'permalink: /docs/%s.html\n' "$base"
     printf -- '---\n'
     printf '{%% raw %%}\n'
-    # Drop the first H1 (the layout already renders the title), then rewrite links:
-    #  - ../PATH (escapes docs/) -> GitHub blob URL so it still resolves
-    #  - between docs: (X.md) / (./X.md) / (docs/X.md) -> (X.html); keep #anchor
-    awk 'BEGIN{dropped=0} /^# /&&!dropped{dropped=1;next} {print}' "$f" | sed -E \
-      -e 's@\]\(\.\./([A-Za-z0-9._/-]+)\)@](https://github.com/olafkfreund/nixos-template/blob/main/\1)@g' \
-      -e 's@\]\(\./([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
-      -e 's@\]\(docs/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g' \
-      -e 's@\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)@](\1.html\2)@g'
+    # Drop the first H1 (the layout already renders the title), then rewrite links
+    # existence-aware (see rewrite-links.py): inter-doc .md -> .html when the doc
+    # exists, otherwise -> GitHub source, so the site never has internal 404s.
+    awk 'BEGIN{dropped=0} /^# /&&!dropped{dropped=1;next} {print}' "$f" \
+      | DOCS_SRC="$SRC" python3 "$(dirname "$0")/rewrite-links.py"
     printf '\n{%% endraw %%}\n'
   } > "$out"
 

--- a/site/scripts/rewrite-links.py
+++ b/site/scripts/rewrite-links.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Rewrite Markdown links in an imported doc (reads stdin, writes stdout).
+
+Rules (DOCS_SRC env points at the repo docs/ folder):
+  - ../PATH (escapes docs/)        -> GitHub blob URL
+  - (X.md) / (./X.md) / (docs/X.md):
+        target doc exists in DOCS_SRC -> X.html   (resolves between site pages)
+        target doc missing           -> GitHub blob URL (never an on-site 404)
+  - http(s):, mailto:, #anchor      -> left unchanged
+A trailing #anchor is preserved in all cases.
+"""
+import os
+import re
+import sys
+
+DOCS = os.environ.get("DOCS_SRC", "docs")
+BLOB = "https://github.com/olafkfreund/nixos-template/blob/main"
+LINK = re.compile(r"\]\(([^)\s]+)\)")
+
+
+def rewrite(target: str) -> str:
+    frag = ""
+    if "#" in target:
+        target, frag = target.split("#", 1)
+        frag = "#" + frag
+
+    if target.startswith(("http://", "https://", "mailto:", "/")) or target == "":
+        return f"]({target}{frag})"
+
+    # Links that escape the docs/ folder -> point at the repo source.
+    if target.startswith("../"):
+        return f"]({BLOB}/{target.lstrip('./')}{frag})"
+
+    if target.endswith(".md"):
+        name = target[3:] if target.startswith("./") else target
+        name = name[5:] if name.startswith("docs/") else name
+        base = os.path.basename(name)
+        if os.path.isfile(os.path.join(DOCS, base)):
+            return f"]({base[:-3]}.html{frag})"
+        # Unknown doc: send readers to the repo instead of a dead site page.
+        return f"]({BLOB}/docs/{base}{frag})"
+
+    return f"]({target}{frag})"
+
+
+sys.stdout.write(LINK.sub(lambda m: rewrite(m.group(1)), sys.stdin.read()))


### PR DESCRIPTION
## Problem
`https://olafkfreund.github.io/nixos-template/getting-started/` (and `/features/`) returned **404**.

## Root cause
The nav links to `/getting-started/` and `/features/` (trailing-slash "pretty" URLs), but those pages had **no `permalink`**, so Jekyll published them at `/getting-started.html` / `/features.html`. (`/documentation/` worked only because it already had an explicit permalink.)

## Fixes
- Add `permalink: /getting-started/` and `permalink: /features/` so the pages publish where the nav points.
- Replace the `sed` link-rewriter with **`rewrite-links.py`**: an inter-doc `.md` link becomes `.html` **only when that doc actually exists**; otherwise it points at the GitHub source — so a dangling doc link can never 404 on the site.
- Fix the one genuinely dead link: `docs/ZERO-CONFIGURATION.md` linked `./PROFILE-SYSTEM.md` (a doc that was never written) → now links to `home/profiles` on GitHub.

## Verification
Built the whole site locally and crawled **all 32 pages** for internal links: **0 broken**. Confirmed `getting-started/index.html` and `features/index.html` are produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
