### PR TITLE
Fix networking.wireless.enable conflict on NixOS 26.05 (restore green flake check)

### DIFF
--- a/modules/core/networking.nix
+++ b/modules/core/networking.nix
@@ -6,8 +6,10 @@
     # NetworkManager for desktop systems (keep mkDefault - some may want systemd-networkd)
     networkmanager.enable = lib.mkDefault true;
 
-    # wpa_supplicant conflicts with NetworkManager (automatic)
-    wireless.enable = false;
+    # wpa_supplicant conflicts with NetworkManager; the template manages wifi
+    # via NetworkManager, so force the standalone service off. mkForce is needed
+    # because newer nixpkgs' networkmanager module defaults this to true.
+    wireless.enable = lib.mkForce false;
 
     # Fast DNS servers (opinionated choice for template)
     nameservers = [


### PR DESCRIPTION
Follow-up to #20. The 26.05 nixpkgs bump made NetworkManager's module set `networking.wireless.enable = true`, conflicting with the template's explicit `false` and breaking `nix flake check` (e.g. `desktop-template`).

Fix: `lib.mkForce false` in `modules/core/networking.nix` — the template manages wifi via NetworkManager, so the standalone wpa_supplicant service stays off. Verified: `nix flake check` is green again (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)