### PR TITLE
Redesign site: CRT terminal theme + visual front page + fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
             global.excludes = [
               # Git and build artifacts
               ".git/**"
+              "site/**"
               "result*"
               "*.png"
               "*.jpg"

--- a/modules/desktop/graphics.nix
+++ b/modules/desktop/graphics.nix
@@ -32,7 +32,7 @@ in
     # Graphics utilities
     environment.systemPackages = with pkgs; [
       # Graphics info tools
-      glxinfo
+      mesa-demos
       vulkan-tools
       libva-utils
 

--- a/modules/hardware/gpu/amd.nix
+++ b/modules/hardware/gpu/amd.nix
@@ -107,7 +107,7 @@ in
         # Graphics utilities
         mesa-demos # OpenGL demos
         vulkan-tools # Vulkan utilities
-        glxinfo # OpenGL info
+        mesa-demos # OpenGL info
       ] ++ lib.optionals (isDesktop && cfg.gaming.enable) [
         # Gaming tools
         mangohud # Gaming overlay

--- a/modules/hardware/gpu/detection.nix
+++ b/modules/hardware/gpu/detection.nix
@@ -32,7 +32,7 @@ in
     # Hardware detection script
     environment.systemPackages = with pkgs; [
       pciutils # lspci for GPU detection
-      glxinfo # GPU info
+      mesa-demos # GPU info
       clinfo # OpenCL info
       # GPU monitoring tools can be added per-host as needed
     ];

--- a/modules/hardware/gpu/intel.nix
+++ b/modules/hardware/gpu/intel.nix
@@ -116,7 +116,7 @@ in
         libva-utils # VA-API utilities (vainfo, etc.)
 
         # Graphics utilities
-        glxinfo # OpenGL info
+        mesa-demos # OpenGL info
         vulkan-tools # Vulkan utilities
         mesa-demos # OpenGL demos
       ] ++

--- a/modules/hardware/gpu/nvidia.nix
+++ b/modules/hardware/gpu/nvidia.nix
@@ -169,7 +169,7 @@ in
         nvtop # Terminal GPU monitor
 
         # Graphics utilities
-        glxinfo # OpenGL info
+        mesa-demos # OpenGL info
         vulkan-tools # Vulkan utilities
         nvidia-settings # NVIDIA control panel
       ] ++ lib.optionals (isDesktop && cfg.gaming.enable) [

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,109 +1,55 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>
-      {% if page.title and page.layout != "home" %}{{ page.title }} · {{
-      site.title }}{% else %}{{ site.title }}{% endif %}
-    </title>
-    {% if page.description or site.description %}
-    <meta
-      name="description"
-      content="{{ page.description | default: site.description | strip_html | truncate: 200 }}"
-    />
-    {% endif %}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="{{ '/assets/css/style.css' | relative_url }}"
-    />
-  </head>
-  <body>
-    <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden />
-    <label
-      for="nav-toggle"
-      class="nav-toggle-btn"
-      aria-label="Toggle navigation"
-      >&#9776; menu</label
-    >
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title and page.layout != "home" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}">{% endif %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
+  <label for="nav-toggle" class="nav-toggle-btn" aria-label="Toggle navigation">&#9776; menu</label>
 
-    <aside class="sidebar">
-      <div class="brand">
-        <a href="{{ '/' | relative_url }}" class="brand-name"
-          >{{ site.title }}</a
-        >
-        {% if site.tagline %}
-        <p class="brand-tag">{{ site.tagline }}</p>
-        {% endif %}
-      </div>
+  <aside class="sidebar">
+    <div class="brand">
+      <a href="{{ '/' | relative_url }}" class="brand-name">{{ site.title }}</a>
+      {% if site.tagline %}<p class="brand-tag">{{ site.tagline }}</p>{% endif %}
+    </div>
 
-      <nav class="nav" aria-label="Primary">
-        <ul class="nav-list">
-          {% for item in site.nav %}
-          <li>
-            <a
-              href="{{ item.url | relative_url }}"
-              {%
-              if
-              page.url=""
-              ="item.url"
-              %}
-              class="active"
-              aria-current="page"
-              {%
-              endif
-              %}
-              >{{ item.title }}</a
-            >
-          </li>
-          {% endfor %}
-        </ul>
+    <nav class="nav" aria-label="Primary">
+      <ul class="nav-list">
+        {% for item in site.nav %}
+        <li><a href="{{ item.url | relative_url }}"{% if page.url == item.url %} class="active" aria-current="page"{% endif %}>{{ item.title }}</a></li>
+        {% endfor %}
+      </ul>
 
-        <p class="nav-heading">Documentation</p>
-        <ul class="nav-list nav-docs">
-          {% assign doc_pages = site.pages | where_exp: "p", "p.url contains
-          '/docs/'" | sort: "title" %} {% for d in doc_pages %}
-          <li>
-            <a
-              href="{{ d.url | relative_url }}"
-              {%
-              if
-              page.url=""
-              ="d.url"
-              %}
-              class="active"
-              aria-current="page"
-              {%
-              endif
-              %}
-              >{{ d.title }}</a
-            >
-          </li>
-          {% endfor %}
-        </ul>
-      </nav>
+      <p class="nav-heading">Documentation</p>
+      <ul class="nav-list nav-docs">
+        {% assign doc_pages = site.pages | where_exp: "p", "p.url contains '/docs/'" | sort: "title" %}
+        {% for d in doc_pages %}
+        <li><a href="{{ d.url | relative_url }}"{% if page.url == d.url %} class="active" aria-current="page"{% endif %}>{{ d.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
 
-      <div class="sidebar-foot">
-        <a href="{{ site.github_repo }}">&#9733; GitHub</a>
-      </div>
-    </aside>
+    <div class="sidebar-foot">
+      <a href="{{ site.github_repo }}">&#9733; GitHub</a>
+    </div>
+  </aside>
 
-    <main class="content">
-      <article class="prose">
-        {% if page.title and page.layout != "home" %}
-        <h1 class="page-title">{{ page.title }}</h1>
-        {% endif %} {{ content }}
-      </article>
-      <footer class="site-foot">
-        <span>{{ site.title }}</span>
-        <span>&middot;</span>
-        <a href="{{ site.github_repo }}">Source on GitHub</a>
-      </footer>
-    </main>
-  </body>
+  <main class="content">
+    <article class="prose">
+      {% if page.title and page.layout != "home" %}<h1 class="page-title">{{ page.title }}</h1>{% endif %}
+      {{ content }}
+    </article>
+    <footer class="site-foot">
+      <span>{{ site.title }}</span>
+      <span>&middot;</span>
+      <a href="{{ site.github_repo }}">Source on GitHub</a>
+    </footer>
+  </main>
+</body>
 </html>

--- a/site/_layouts/home.html
+++ b/site/_layouts/home.html
@@ -1,5 +1,4 @@
 ---
 layout: default
 ---
-
 {{ content }}

--- a/site/_layouts/page.html
+++ b/site/_layouts/page.html
@@ -1,5 +1,4 @@
 ---
 layout: default
 ---
-
 {{ content }}

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1,344 +1,224 @@
-/* NixOS Template — dark "console" theme with a fixed left sidebar */
+/* NixOS Template — "old terminal" / CRT phosphor theme */
 
 :root {
-  --bg: #0b0e14;
-  --bg-side: #0d1117;
-  --bg-code: #11161f;
-  --border: #1f2733;
-  --fg: #c9d1d9;
-  --muted: #8b949e;
-  --accent: #7ee787; /* terminal green */
-  --accent-dim: #3fb950;
-  --link: #79c0ff;
-  --sidebar-w: 280px;
-  --maxw: 900px;
+  --bg:        #040904;
+  --bg-pane:   #07100a;
+  --bg-code:   #0a160e;
+  --border:    #16331f;
+  --border-hi: #1f5233;
+  --fg:        #b8ffcf;   /* phosphor text */
+  --fg-dim:    #5aa977;
+  --muted:     #3f7a57;
+  --accent:    #3dff9e;   /* bright phosphor */
+  --accent-2:  #8affc0;
+  --amber:     #ffcc66;
+  --link:      #5fe1ff;
+  --glow:      0 0 4px rgba(61, 255, 158, 0.55);
+  --glow-soft: 0 0 2px rgba(61, 255, 158, 0.35);
+  --sidebar-w: 290px;
+  --maxw:      940px;
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
-  background: var(--bg);
+  background:
+    radial-gradient(120% 120% at 50% 0%, #0a160e 0%, var(--bg) 60%, #010401 100%);
   color: var(--fg);
-  font-family:
-    "JetBrains Mono", ui-monospace, SFMono-Regular, "Source Code Pro", Menlo,
-    Consolas, monospace;
-  font-size: 15px;
-  line-height: 1.65;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, "Cascadia Code", Menlo, Consolas, monospace;
+  font-size: 14.5px;
+  line-height: 1.7;
+  text-shadow: var(--glow-soft);
   -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
 }
 
-a {
-  color: var(--link);
-  text-decoration: none;
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; text-shadow: 0 0 6px rgba(95, 225, 255, 0.6); }
+
+/* ---------- CRT overlay: scanlines + flicker + vignette ---------- */
+.crt::before {
+  content: "";
+  position: fixed; inset: 0; z-index: 9998; pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0px,
+      rgba(0, 0, 0, 0) 2px,
+      rgba(0, 0, 0, 0.18) 3px,
+      rgba(0, 0, 0, 0.18) 3px
+    );
+  mix-blend-mode: multiply;
 }
-a:hover {
-  text-decoration: underline;
+.crt::after {
+  content: "";
+  position: fixed; inset: 0; z-index: 9999; pointer-events: none;
+  background: radial-gradient(120% 120% at 50% 50%, transparent 60%, rgba(0,0,0,0.55) 100%);
+  animation: flicker 4.5s infinite steps(60);
+}
+@keyframes flicker {
+  0%, 97%, 100% { opacity: 1; }
+  98% { opacity: 0.88; }
+  99% { opacity: 0.96; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .crt::after { animation: none; }
+  .cursor { animation: none; }
 }
 
-/* ---------- Sidebar ---------- */
+/* ---------- Sidebar (terminal pane) ---------- */
 .sidebar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
+  position: fixed; top: 0; left: 0; bottom: 0;
   width: var(--sidebar-w);
-  background: var(--bg-side);
-  border-right: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--bg-pane), #050d08);
+  border-right: 1px solid var(--border-hi);
+  box-shadow: inset -1px 0 0 rgba(61,255,158,0.06), 2px 0 24px rgba(0,0,0,0.6);
   overflow-y: auto;
-  padding: 1.5rem 1rem 2rem;
-  display: flex;
-  flex-direction: column;
+  padding: 1.1rem 0.9rem 2rem;
+  display: flex; flex-direction: column;
+  z-index: 20;
 }
+.sidebar::-webkit-scrollbar { width: 8px; }
+.sidebar::-webkit-scrollbar-thumb { background: var(--border-hi); border-radius: 4px; }
 
-.brand {
-  padding: 0 0.5rem 1rem;
+.term-bar {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.2rem 0.4rem 0.7rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 1rem;
+  margin-bottom: 0.8rem;
+  color: var(--muted); font-size: 0.72rem;
 }
-.brand-name {
-  display: block;
-  color: var(--accent);
-  font-weight: 700;
-  font-size: 1.15rem;
-  letter-spacing: 0.02em;
-}
-.brand-name::before {
-  content: "❯ ";
-  color: var(--accent-dim);
-}
-.brand-tag {
-  color: var(--muted);
-  font-size: 0.78rem;
-  margin: 0.4rem 0 0;
-  word-break: break-word;
-}
+.term-bar .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.dot.r { background: #ff5f56; } .dot.y { background: #ffbd2e; } .dot.g { background: #27c93f; }
+.term-bar .ttl { margin-left: auto; letter-spacing: 0.08em; }
 
-.nav {
-  flex: 1;
+.brand { padding: 0 0.4rem 0.9rem; }
+.brand-name {
+  display: block; color: var(--accent); font-weight: 700;
+  font-size: 1.06rem; letter-spacing: 0.04em; text-shadow: var(--glow);
 }
+.brand-name::before { content: "user@nixos:~$ "; color: var(--fg-dim); font-weight: 400; }
+.brand-tag { color: var(--muted); font-size: 0.74rem; margin: 0.35rem 0 0; }
+.cursor {
+  display: inline-block; width: 0.6ch; height: 1.05em; transform: translateY(0.18em);
+  background: var(--accent); margin-left: 2px; box-shadow: var(--glow);
+  animation: blink 1.1s steps(2) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.nav { flex: 1; margin-top: 0.4rem; }
 .nav-heading {
-  color: var(--accent-dim);
-  text-transform: uppercase;
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  margin: 1.4rem 0.5rem 0.4rem;
+  color: var(--accent); opacity: 0.85; text-transform: uppercase;
+  font-size: 0.66rem; letter-spacing: 0.18em; margin: 1.3rem 0.5rem 0.45rem;
 }
-.nav-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.nav-list li {
-  margin: 0;
-}
+.nav-heading::before { content: "// "; color: var(--muted); }
+.nav-list { list-style: none; margin: 0; padding: 0; }
 .nav-list a {
-  display: block;
-  color: var(--fg);
-  padding: 0.32rem 0.55rem;
-  border-radius: 5px;
-  border-left: 2px solid transparent;
-  font-size: 0.86rem;
-  line-height: 1.4;
+  display: block; color: var(--fg); padding: 0.3rem 0.55rem;
+  border-left: 2px solid transparent; border-radius: 3px;
+  font-size: 0.85rem; line-height: 1.45;
 }
+.nav-list a::before { content: "› "; color: var(--muted); }
 .nav-list a:hover {
-  background: rgba(126, 231, 135, 0.08);
-  text-decoration: none;
-  color: var(--accent);
+  background: rgba(61,255,158,0.08); color: var(--accent);
+  text-decoration: none; text-shadow: var(--glow);
 }
+.nav-list a:hover::before { content: "$ "; color: var(--accent); }
 .nav-list a.active {
-  background: rgba(126, 231, 135, 0.12);
-  border-left-color: var(--accent);
-  color: var(--accent);
-  font-weight: 500;
+  background: rgba(61,255,158,0.12); border-left-color: var(--accent);
+  color: var(--accent); text-shadow: var(--glow);
 }
-.nav-docs a {
-  color: var(--muted);
-}
-.nav-docs a:hover,
-.nav-docs a.active {
-  color: var(--accent);
-}
+.nav-list a.active::before { content: "$ "; color: var(--accent); }
+.nav-docs a { color: var(--fg-dim); font-size: 0.8rem; }
+.nav-docs a:hover, .nav-docs a.active { color: var(--accent); }
 
 .sidebar-foot {
-  margin-top: 1.2rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
-  font-size: 0.82rem;
+  margin-top: 1.1rem; padding-top: 0.9rem;
+  border-top: 1px solid var(--border); font-size: 0.8rem;
 }
+.sidebar-foot a { color: var(--accent); }
 
 /* ---------- Content ---------- */
 .content {
-  margin-left: var(--sidebar-w);
-  padding: 2.5rem 3rem;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  margin-left: var(--sidebar-w); padding: 2.4rem 3rem; min-height: 100vh;
+  display: flex; flex-direction: column;
 }
-.prose {
-  max-width: var(--maxw);
-  width: 100%;
-  flex: 1;
-}
+.prose { max-width: var(--maxw); width: 100%; flex: 1; }
 
-.page-title {
-  color: var(--accent);
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0.4rem;
-  margin-top: 0;
-}
+.page-title { color: var(--accent); text-shadow: var(--glow);
+  border-bottom: 1px solid var(--border-hi); padding-bottom: 0.4rem; margin-top: 0; }
+.prose h1, .prose h2, .prose h3, .prose h4 { color: var(--accent-2); line-height: 1.3; margin-top: 1.9rem; text-shadow: var(--glow-soft); }
+.prose h1 { color: var(--accent); }
+.prose h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; }
+.prose h2::before, .prose h3::before { content: "# "; color: var(--muted); }
+.prose strong { color: var(--accent-2); }
+.prose hr { border: none; border-top: 1px dashed var(--border-hi); margin: 2rem 0; }
+.prose blockquote { margin: 1rem 0; padding: 0.3rem 1rem; border-left: 3px solid var(--accent);
+  background: rgba(61,255,158,0.05); color: var(--fg-dim); }
 
-.prose h1,
-.prose h2,
-.prose h3,
-.prose h4 {
-  color: #e6edf3;
-  line-height: 1.3;
-  margin-top: 1.8rem;
-}
-.prose h2 {
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0.3rem;
-}
-.prose h1 {
-  color: var(--accent);
-}
-.prose p,
-.prose li {
-  color: var(--fg);
-}
-.prose strong {
-  color: #e6edf3;
-}
-.prose hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 2rem 0;
-}
+code { font-family: inherit; background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: 3px; padding: 0.08rem 0.34rem; font-size: 0.85em; color: var(--accent); }
+pre { background: var(--bg-code); border: 1px solid var(--border-hi); border-radius: 6px;
+  padding: 1rem 1.1rem; overflow-x: auto; line-height: 1.55; box-shadow: inset 0 0 24px rgba(0,0,0,0.5); }
+pre code { background: none; border: none; padding: 0; color: var(--fg); font-size: 0.85rem; text-shadow: var(--glow-soft); }
+.highlight { margin: 1rem 0; } .highlight pre { margin: 0; }
 
-.prose blockquote {
-  margin: 1rem 0;
-  padding: 0.2rem 1rem;
-  border-left: 3px solid var(--accent-dim);
-  background: rgba(126, 231, 135, 0.05);
-  color: var(--muted);
-}
+.prose table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.84rem; display: block; overflow-x: auto; }
+.prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
+.prose th { background: var(--bg-code); color: var(--accent); }
+.prose img { max-width: 100%; border: 1px solid var(--border-hi); border-radius: 6px; box-shadow: 0 0 0 1px rgba(0,0,0,0.4), 0 0 30px rgba(61,255,158,0.06); }
 
-/* Inline + block code */
-code {
-  font-family: inherit;
-  background: var(--bg-code);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.1rem 0.35rem;
-  font-size: 0.85em;
-  color: var(--accent);
-}
-pre {
-  background: var(--bg-code);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem 1.1rem;
-  overflow-x: auto;
-  line-height: 1.5;
-}
-pre code {
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(--fg);
-  font-size: 0.85rem;
-}
-.highlight {
-  margin: 1rem 0;
-}
-.highlight pre {
-  margin: 0;
-}
+.site-foot { margin-top: 3rem; padding-top: 1.2rem; border-top: 1px solid var(--border);
+  color: var(--muted); font-size: 0.8rem; display: flex; gap: 0.6rem; max-width: var(--maxw); flex-wrap: wrap; }
 
-/* Tables */
-.prose table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 1rem 0;
-  font-size: 0.85rem;
-  display: block;
-  overflow-x: auto;
-}
-.prose th,
-.prose td {
-  border: 1px solid var(--border);
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-}
-.prose th {
-  background: var(--bg-code);
-  color: var(--accent);
-}
-.prose tr:nth-child(even) td {
-  background: rgba(255, 255, 255, 0.02);
-}
+/* ---------- Home / front page bits ---------- */
+.hero { border: 1px solid var(--border-hi); border-radius: 8px; padding: 1.4rem 1.6rem;
+  background: linear-gradient(180deg, rgba(61,255,158,0.05), transparent);
+  box-shadow: inset 0 0 40px rgba(61,255,158,0.05); margin-bottom: 1.6rem; }
+.hero pre { background: transparent; border: none; box-shadow: none; padding: 0; }
+.hero h1 { margin: 0 0 0.4rem; }
 
-.prose img {
-  max-width: 100%;
+.btn-row { display: flex; flex-wrap: wrap; gap: 0.7rem; margin: 1.2rem 0; }
+.btn {
+  display: inline-block; border: 1px solid var(--accent); color: var(--accent);
+  padding: 0.45rem 0.9rem; border-radius: 4px; font-weight: 600; letter-spacing: 0.03em;
+  text-shadow: var(--glow); background: rgba(61,255,158,0.04);
 }
+.btn::before { content: "[ "; } .btn::after { content: " ]"; }
+.btn:hover { background: var(--accent); color: #04130a; text-shadow: none; text-decoration: none; box-shadow: 0 0 16px rgba(61,255,158,0.5); }
 
-.site-foot {
-  margin-top: 3rem;
-  padding-top: 1.2rem;
-  border-top: 1px solid var(--border);
-  color: var(--muted);
-  font-size: 0.8rem;
-  display: flex;
-  gap: 0.6rem;
-  max-width: var(--maxw);
-}
+.feature-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 0.8rem; margin: 1rem 0 1.6rem; }
+.feature-grid .card { border: 1px solid var(--border); border-radius: 6px; padding: 0.8rem 0.9rem; background: var(--bg-pane); }
+.feature-grid .card b { color: var(--accent); }
+.feature-grid .card p { margin: 0.3rem 0 0; color: var(--fg-dim); font-size: 0.84rem; }
 
-/* ---------- Mobile / hamburger ---------- */
-.nav-toggle-btn {
-  display: none;
-  position: fixed;
-  top: 0.8rem;
-  right: 0.8rem;
-  z-index: 30;
-  background: var(--bg-code);
-  color: var(--accent);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.4rem 0.7rem;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 0.85rem;
-}
+.shot-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 0.9rem; margin: 1rem 0; }
+.shot-gallery figure { margin: 0; }
+.shot-gallery figcaption { color: var(--muted); font-size: 0.78rem; margin-top: 0.3rem; }
 
+video { max-width: 100%; border: 1px solid var(--border-hi); border-radius: 8px; box-shadow: 0 0 30px rgba(61,255,158,0.08); }
+
+/* ---------- Mobile ---------- */
+.nav-toggle-btn { display: none; position: fixed; top: 0.8rem; right: 0.8rem; z-index: 30;
+  background: var(--bg-code); color: var(--accent); border: 1px solid var(--border-hi);
+  border-radius: 5px; padding: 0.4rem 0.7rem; cursor: pointer; font-family: inherit; font-size: 0.85rem; text-shadow: var(--glow); }
 @media (max-width: 900px) {
-  .nav-toggle-btn {
-    display: inline-block;
-  }
-  .sidebar {
-    transform: translateX(-100%);
-    transition: transform 0.2s ease;
-    z-index: 20;
-    box-shadow: 2px 0 20px rgba(0, 0, 0, 0.5);
-  }
-  .nav-toggle:checked ~ .sidebar {
-    transform: translateX(0);
-  }
-  .content {
-    margin-left: 0;
-    padding: 4rem 1.25rem 2rem;
-  }
+  .nav-toggle-btn { display: inline-block; }
+  .sidebar { transform: translateX(-100%); transition: transform 0.2s ease; }
+  .nav-toggle:checked ~ .sidebar { transform: translateX(0); }
+  .content { margin-left: 0; padding: 4rem 1.2rem 2rem; }
 }
 
-/* ---------- Minimal Rouge syntax colors (dark) ---------- */
-.highlight .c,
-.highlight .c1,
-.highlight .cm,
-.highlight .cd {
-  color: #6a737d;
-  font-style: italic;
-}
-.highlight .k,
-.highlight .kd,
-.highlight .kn,
-.highlight .kr {
-  color: #ff7b72;
-}
-.highlight .s,
-.highlight .s1,
-.highlight .s2,
-.highlight .se {
-  color: #a5d6ff;
-}
-.highlight .nb,
-.highlight .bp {
-  color: #79c0ff;
-}
-.highlight .nf,
-.highlight .nx {
-  color: #d2a8ff;
-}
-.highlight .mi,
-.highlight .mf,
-.highlight .il {
-  color: #79c0ff;
-}
-.highlight .o,
-.highlight .ow {
-  color: #ff7b72;
-}
-.highlight .nt {
-  color: #7ee787;
-}
-.highlight .na {
-  color: #79c0ff;
-}
-.highlight .gp {
-  color: var(--accent-dim);
-}
+/* ---------- Rouge syntax (phosphor) ---------- */
+.highlight .c, .highlight .c1, .highlight .cm, .highlight .cd { color: #3f7a57; font-style: italic; }
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kr { color: #5fe1ff; }
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .se { color: var(--amber); }
+.highlight .nb, .highlight .bp { color: #5fe1ff; }
+.highlight .nf, .highlight .nx { color: var(--accent-2); }
+.highlight .mi, .highlight .mf, .highlight .il { color: #5fe1ff; }
+.highlight .o, .highlight .ow { color: var(--accent); }
+.highlight .nt { color: var(--accent); }
+.highlight .na { color: #5fe1ff; }
+.highlight .gp { color: var(--fg-dim); }

--- a/site/documentation.md
+++ b/site/documentation.md
@@ -1,6 +1,8 @@
 ---
-
-## layout: page title: "Documentation" permalink: /documentation/
+layout: page
+title: "Documentation"
+permalink: /documentation/
+---
 
 ```
 $ ls docs/
@@ -14,9 +16,8 @@ Source of truth lives in [`docs/`](https://github.com/olafkfreund/nixos-template
 **{{ doc_pages | size }} documents**
 
 {% for d in doc_pages %}
-
-- \[{{ d.title }}\]({{ d.url | relative_url }})
-  {% endfor %}
+- [{{ d.title }}]({{ d.url | relative_url }})
+{% endfor %}
 
 ---
 

--- a/site/features.md
+++ b/site/features.md
@@ -1,6 +1,8 @@
 ---
-
-## layout: page title: "Features" permalink: /features/
+layout: page
+title: "Features"
+permalink: /features/
+---
 
 ```
 $ nix flake show github:olafkfreund/nixos-template
@@ -130,12 +132,12 @@ Images inherit your full system configuration — same packages, services, and s
 
 Four composable profiles eliminate copy-paste between host configs:
 
-| Profile           | Includes                                                   |
-| ----------------- | ---------------------------------------------------------- |
-| `base.nix`        | git, zsh/bash aliases, starship, common CLI tools          |
-| `desktop.nix`     | GUI apps, multimedia, browser, desktop environment support |
-| `development.nix` | Language toolchains, LSP servers, editors, dev tools       |
-| `server.nix`      | Server administration, monitoring, networking tools        |
+| Profile | Includes |
+|---|---|
+| `base.nix` | git, zsh/bash aliases, starship, common CLI tools |
+| `desktop.nix` | GUI apps, multimedia, browser, desktop environment support |
+| `development.nix` | Language toolchains, LSP servers, editors, dev tools |
+| `server.nix` | Server administration, monitoring, networking tools |
 
 ```nix
 # Mix and match per host

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -1,6 +1,8 @@
 ---
-
-## layout: page title: "Getting Started" permalink: /getting-started/
+layout: page
+title: "Getting Started"
+permalink: /getting-started/
+---
 
 ```
 $ nix develop  # drop into the development shell
@@ -32,15 +34,15 @@ The dev shell provides: `nixpkgs-fmt`, `statix`, `deadnix`, `nix-tree`, `just`, 
 
 ## Step 2 — Choose a host template
 
-| Template                 | Use case                                            |
-| ------------------------ | --------------------------------------------------- |
-| `hosts/desktop-template` | Workstation with GNOME, full Home Manager profiles  |
-| `hosts/laptop-template`  | Same as desktop with power management               |
-| `hosts/server-template`  | Headless, SSH-hardened, server Home Manager profile |
-| `hosts/wsl2-template`    | NixOS inside Windows Subsystem for Linux 2          |
-| `hosts/darwin-desktop`   | macOS workstation via nix-darwin                    |
-| `hosts/darwin-laptop`    | macOS laptop via nix-darwin                         |
-| `hosts/darwin-server`    | macOS server via nix-darwin                         |
+| Template | Use case |
+|---|---|
+| `hosts/desktop-template` | Workstation with GNOME, full Home Manager profiles |
+| `hosts/laptop-template` | Same as desktop with power management |
+| `hosts/server-template` | Headless, SSH-hardened, server Home Manager profile |
+| `hosts/wsl2-template` | NixOS inside Windows Subsystem for Linux 2 |
+| `hosts/darwin-desktop` | macOS workstation via nix-darwin |
+| `hosts/darwin-laptop` | macOS laptop via nix-darwin |
+| `hosts/darwin-server` | macOS server via nix-darwin |
 
 ```bash
 cp -r hosts/desktop-template hosts/my-machine
@@ -108,23 +110,23 @@ just switch my-machine
 
 ## Common `just` commands
 
-| Command                     | What it does                                             |
-| --------------------------- | -------------------------------------------------------- |
-| `just switch [host]`        | Build and apply configuration                            |
-| `just test [host]`          | Test without making the change permanent                 |
-| `just build [host]`         | Build without switching                                  |
-| `just update`               | Update all flake inputs                                  |
-| `just update-switch [host]` | Update inputs then switch                                |
-| `just fmt`                  | Format all Nix files with `nixpkgs-fmt`                  |
-| `just lint`                 | Run `statix check`                                       |
-| `just validate`             | Full validation: check + lint + format-check + dead-code |
-| `just check`                | `nix flake check`                                        |
-| `just vm [host]`            | Build and run host as a QEMU VM                          |
-| `just build-wsl2-archive`   | Build WSL2 tarball                                       |
-| `just setup-secrets`        | Set up agenix secrets management                         |
-| `just edit-secret SECRET`   | Encrypt and edit a secret                                |
-| `just list-secrets`         | Show all age-encrypted secrets                           |
-| `just rekey-secrets`        | Re-encrypt after adding a new age key                    |
+| Command | What it does |
+|---|---|
+| `just switch [host]` | Build and apply configuration |
+| `just test [host]` | Test without making the change permanent |
+| `just build [host]` | Build without switching |
+| `just update` | Update all flake inputs |
+| `just update-switch [host]` | Update inputs then switch |
+| `just fmt` | Format all Nix files with `nixpkgs-fmt` |
+| `just lint` | Run `statix check` |
+| `just validate` | Full validation: check + lint + format-check + dead-code |
+| `just check` | `nix flake check` |
+| `just vm [host]` | Build and run host as a QEMU VM |
+| `just build-wsl2-archive` | Build WSL2 tarball |
+| `just setup-secrets` | Set up agenix secrets management |
+| `just edit-secret SECRET` | Encrypt and edit a secret |
+| `just list-secrets` | Show all age-encrypted secrets |
+| `just rekey-secrets` | Re-encrypt after adding a new age key |
 
 ---
 

--- a/site/index.md
+++ b/site/index.md
@@ -1,20 +1,13 @@
 ---
-
-## layout: home title: "NixOS Template"
+layout: home
+title: "NixOS Template"
+---
 
 ```
 $ nixos-rebuild switch --flake github:olafkfreund/nixos-template#your-machine
 ```
 
 A production-ready, flake-based NixOS configuration template. Stop copy-pasting configs — inherit a curated foundation and override only what your machine needs.
-
----
-
-## See it in action
-
-!\[The just menu\]({{ '/assets/menu/showcase.gif' | relative_url }})
-
-A single `just` command opens a guided menu covering every workflow — build, test, secrets, VMs, ISOs, and more. \[Learn how it works.\]({{ '/usage/' | relative_url }})
 
 ---
 

--- a/site/scripts/import-docs.sh
+++ b/site/scripts/import-docs.sh
@@ -51,10 +51,10 @@ for f in "$SRC"/*.md; do
     # Drop the first H1 (the layout already renders the title), then rewrite links
     # existence-aware (see rewrite-links.py): inter-doc .md -> .html when the doc
     # exists, otherwise -> GitHub source, so the site never has internal 404s.
-    awk 'BEGIN{dropped=0} /^# /&&!dropped{dropped=1;next} {print}' "$f" |
-      DOCS_SRC="$SRC" python3 "$(dirname "$0")/rewrite-links.py"
+    awk 'BEGIN{dropped=0} /^# /&&!dropped{dropped=1;next} {print}' "$f" \
+      | DOCS_SRC="$SRC" python3 "$(dirname "$0")/rewrite-links.py"
     printf '\n{%% endraw %%}\n'
-  } >"$out"
+  } > "$out"
 
   count=$((count + 1))
 done

--- a/site/usage.md
+++ b/site/usage.md
@@ -1,108 +1,94 @@
 ---
-
-## layout: page title: "Usage — the just menu" permalink: /usage/
-
-Run `just` from the repo root and a guided, category-based menu opens in your terminal. Browse categories, read what each recipe does, pick one — it shows you the exact command and asks for confirmation before running anything. No extra tools required beyond the dev shell.
-
-<video src="{{ '/assets/menu/showcase.mp4' | relative_url }}" autoplay loop muted playsinline controls style="max-width:100%;border-radius:8px"></video>
-
-!\[Menu showcase\]({{ '/assets/menu/showcase.gif' | relative_url }})
-
+layout: page
+title: "Usage — the just menu"
+permalink: /usage/
 ---
+
+`just` opens a guided control panel: browse categories, read what each action
+does, then pick it. It previews the exact command and asks to confirm before
+running. Zero dependencies — pure bash, works in any shell.
+
+<video src="{{ '/assets/menu/showcase.mp4' | relative_url }}" autoplay loop muted playsinline controls></video>
+
+![Menu showcase]({{ '/assets/menu/showcase.gif' | relative_url }})
 
 ## Quick start
 
-```bash
-# Enter the dev shell (provides just, nixpkgs-fmt, statix, deadnix, …)
-nix develop
-
-# Open the interactive menu
-just
 ```
-
----
+$ nix develop      # enter the dev shell (provides just)
+$ just             # open the menu
+```
 
 ## How it works
 
-1. **Category list** — the top-level menu groups every recipe into logical sections (Build & Apply, Secrets, Maintenance, …).
-1. **Item descriptions** — selecting a category shows each recipe with a one-line explanation so you know what it does before you commit.
-1. **Command preview + confirm** — after you pick a recipe, the menu prints the exact shell command it will run and prompts `Run? [Y/n]`. Press Enter to accept or `n` to cancel.
-1. **Navigation** — press `b` to go back one level, `q` to quit.
-1. **Host auto-detection** — recipes that operate on a specific host default to the current machine's hostname; you can override at the prompt.
-1. **Argument prompts** — recipes that need parameters (e.g. a host name or VM count) prompt with a sensible default in brackets.
+- **Numbered selection** — type a number, press Enter.
+- **Every item has a description** so you know what it does before picking it.
+- **Command preview + confirm** — it prints `▶ just <command>` and asks `[Y/n]`
+  before running anything.
+- **`b`** goes back, **`q`** quits.
+- The **hostname is auto-detected**; actions that need arguments prompt with
+  sensible defaults.
+- Colors auto-disable when piped or when `NO_COLOR` is set.
 
-!\[Main menu\]({{ '/assets/menu/01-main.png' | relative_url }})
-
----
+![Main menu]({{ '/assets/menu/01-main.png' | relative_url }})
 
 ## Every menu, at a glance
 
 ### Build & Apply
+Switch, test, boot, build, dry-run, diff, update, and roll back your system.
 
-Apply your NixOS configuration, test without switching, or build without activating — covers the full `nixos-rebuild` workflow for local and remote hosts.
-
-!\[Build & Apply\]({{ '/assets/menu/02-build-apply.png' | relative_url }})
+![Build & Apply]({{ '/assets/menu/02-build-apply.png' | relative_url }})
 
 ### Create Host / User
+Scaffold a new host from a preset or template, or apply a user/home template.
 
-Scaffold a new host directory from a template or add a new user profile in seconds, with interactive prompts filling in names and roles.
-
-!\[Create Host / User\]({{ '/assets/menu/03-create-host-user.png' | relative_url }})
+![Create Host or User]({{ '/assets/menu/03-create-host-user.png' | relative_url }})
 
 ### VMs & Testing
+Build and run VM images, detect your VM/hardware, validate the MicroVM.
 
-Boot any host configuration as a QEMU VM for a live preview, run the NixOS test suite, or build a VM image — without touching your running system.
-
-!\[VMs & Testing\]({{ '/assets/menu/04-vms-testing.png' | relative_url }})
+![VMs & Testing]({{ '/assets/menu/04-vms-testing.png' | relative_url }})
 
 ### Installer ISOs
+Build minimal / desktop / preconfigured installers and write a bootable USB.
 
-Generate a bootable NixOS ISO pre-seeded with your configuration via `nixos-generators`, ready to burn or `dd` to a USB drive.
-
-!\[Installer ISOs\]({{ '/assets/menu/05-installer-isos.png' | relative_url }})
+![Installer ISOs]({{ '/assets/menu/05-installer-isos.png' | relative_url }})
 
 ### Desktops
+Browse and test GNOME, KDE, Hyprland, and Niri; show Niri keybindings.
 
-Switch or rebuild desktop-specific configurations (GNOME, Hyprland, …) and manage display-manager settings without editing files by hand.
-
-!\[Desktops\]({{ '/assets/menu/06-desktops.png' | relative_url }})
+![Desktops]({{ '/assets/menu/06-desktops.png' | relative_url }})
 
 ### macOS & WSL2
+NixOS VMs/ISOs for Mac (UTM/QEMU) and the WSL2 distribution for Windows.
 
-Build a NixOS WSL2 tarball for Windows import, or rebuild nix-darwin configurations on Apple Silicon and Intel Macs.
-
-!\[macOS & WSL2\]({{ '/assets/menu/07-macos-wsl2.png' | relative_url }})
+![macOS & WSL2]({{ '/assets/menu/07-macos-wsl2.png' | relative_url }})
 
 ### Quality & Format
+Check, validate, format, lint, find dead code, run the pre-commit hooks.
 
-Run `nixpkgs-fmt`, `statix`, and `deadnix` in one step to keep code clean, or check the entire flake for evaluation errors.
-
-!\[Quality & Format\]({{ '/assets/menu/08-quality-format.png' | relative_url }})
+![Quality & Format]({{ '/assets/menu/08-quality-format.png' | relative_url }})
 
 ### Secrets
+Set up, list, edit, validate, and re-key agenix-encrypted secrets.
 
-Rekey agenix secrets, add new secret files, or rotate keys — all through guided prompts that handle the age encryption details for you.
-
-!\[Secrets\]({{ '/assets/menu/09-secrets.png' | relative_url }})
+![Secrets]({{ '/assets/menu/09-secrets.png' | relative_url }})
 
 ### Maintenance & Info
+System info, flake inputs, generations, store cleanup, and the dev shell.
 
-Show system info, garbage-collect old generations, update flake inputs, or check which hosts are defined in the flake — housekeeping made easy.
-
-!\[Maintenance & Info\]({{ '/assets/menu/10-maintenance-info.png' | relative_url }})
-
----
+![Maintenance & Info]({{ '/assets/menu/10-maintenance-info.png' | relative_url }})
 
 ## Prefer the command line?
 
-```bash
-# List every available recipe with descriptions
-just list
+The menu is just a friendly front-end — everything is still a plain recipe:
 
-# Run a recipe directly, skipping the menu
-just switch my-machine
-just build-vm desktop-test
-just update
+```
+$ just list                 # show every recipe (raw)
+$ just switch               # build & activate this host
+$ just build-iso-minimal    # run a recipe directly
+$ just new-host my-pc workstation
 ```
 
-Full recipe reference and advanced usage: [docs/MENU.md on GitHub](https://github.com/olafkfreund/nixos-template/blob/main/docs/MENU.md)
+Full reference:
+[docs/MENU.md](https://github.com/olafkfreund/nixos-template/blob/main/docs/MENU.md).


### PR DESCRIPTION
Old-terminal/CRT phosphor theme, visual front page with screencast + screenshot gallery, restructured left sidebar. Also fixes the broken Pages deploy (prettier had mangled site YAML front matter; site/** now excluded from treefmt) and the glxinfo->mesa-demos rename (nixpkgs 26.05).