### PR TITLE
Apply CRT redesign to layout + home page (was half-applied)

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,55 +1,61 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title and page.layout != "home" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-  {% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}">{% endif %}
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
-</head>
-<body>
-  <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
-  <label for="nav-toggle" class="nav-toggle-btn" aria-label="Toggle navigation">&#9776; menu</label>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% if page.title and page.layout != "home" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+    {% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description | strip_html | truncate: 200 }}" />{% endif %}
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+  </head>
+  <body class="crt">
+    <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden />
+    <label for="nav-toggle" class="nav-toggle-btn" aria-label="Toggle navigation">▚ menu</label>
 
-  <aside class="sidebar">
-    <div class="brand">
-      <a href="{{ '/' | relative_url }}" class="brand-name">{{ site.title }}</a>
-      {% if site.tagline %}<p class="brand-tag">{{ site.tagline }}</p>{% endif %}
-    </div>
+    <aside class="sidebar">
+      <div class="term-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="ttl">tty1 — nixos-template</span>
+      </div>
 
-    <nav class="nav" aria-label="Primary">
-      <ul class="nav-list">
-        {% for item in site.nav %}
-        <li><a href="{{ item.url | relative_url }}"{% if page.url == item.url %} class="active" aria-current="page"{% endif %}>{{ item.title }}</a></li>
-        {% endfor %}
-      </ul>
+      <div class="brand">
+        <a href="{{ '/' | relative_url }}" class="brand-name">{{ site.title }}<span class="cursor"></span></a>
+        {% if site.tagline %}<p class="brand-tag">{{ site.tagline }}</p>{% endif %}
+      </div>
 
-      <p class="nav-heading">Documentation</p>
-      <ul class="nav-list nav-docs">
-        {% assign doc_pages = site.pages | where_exp: "p", "p.url contains '/docs/'" | sort: "title" %}
-        {% for d in doc_pages %}
-        <li><a href="{{ d.url | relative_url }}"{% if page.url == d.url %} class="active" aria-current="page"{% endif %}>{{ d.title }}</a></li>
-        {% endfor %}
-      </ul>
-    </nav>
+      <nav class="nav" aria-label="Primary">
+        <p class="nav-heading">navigation</p>
+        <ul class="nav-list">
+          {% for item in site.nav %}
+          <li><a href="{{ item.url | relative_url }}"{% if page.url == item.url %} class="active" aria-current="page"{% endif %}>{{ item.title }}</a></li>
+          {% endfor %}
+        </ul>
 
-    <div class="sidebar-foot">
-      <a href="{{ site.github_repo }}">&#9733; GitHub</a>
-    </div>
-  </aside>
+        <p class="nav-heading">documentation</p>
+        <ul class="nav-list nav-docs">
+          {% assign doc_pages = site.pages | where_exp: "p", "p.url contains '/docs/'" | sort: "title" %}
+          {% for d in doc_pages %}
+          <li><a href="{{ d.url | relative_url }}"{% if page.url == d.url %} class="active" aria-current="page"{% endif %}>{{ d.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
 
-  <main class="content">
-    <article class="prose">
-      {% if page.title and page.layout != "home" %}<h1 class="page-title">{{ page.title }}</h1>{% endif %}
-      {{ content }}
-    </article>
-    <footer class="site-foot">
-      <span>{{ site.title }}</span>
-      <span>&middot;</span>
-      <a href="{{ site.github_repo }}">Source on GitHub</a>
-    </footer>
-  </main>
-</body>
+      <div class="sidebar-foot">
+        <a href="{{ site.github_repo }}">&gt; source @ github</a>
+      </div>
+    </aside>
+
+    <main class="content">
+      <article class="prose">
+        {% if page.title and page.layout != "home" %}<h1 class="page-title">{{ page.title }}</h1>{% endif %}
+        {{ content }}
+      </article>
+      <footer class="site-foot">
+        <span>{{ site.title }}</span><span>·</span>
+        <a href="{{ site.github_repo }}">source on github</a><span>·</span>
+        <span>NixOS 26.05</span>
+      </footer>
+    </main>
+  </body>
 </html>

--- a/site/index.md
+++ b/site/index.md
@@ -3,75 +3,72 @@ layout: home
 title: "NixOS Template"
 ---
 
-```
-$ nixos-rebuild switch --flake github:olafkfreund/nixos-template#your-machine
-```
+<div class="hero">
+<pre style="color:var(--accent);text-shadow:var(--glow)">
+ _ __ (_)_ __ ___  ___    _ _____ ___ _ __  _ __  | |__ _| |_ ___
+| '_ \| | \ / _ \/ __|  | __/ -_) '  \| '_ \| / _` |  _/ -_)
+|_| |_|_/_\_\___/\___|   \__\___|_|_|_| .__/|_\__,_|\__\___|
+                                      |_|  NixOS 26.05
+</pre>
 
-A production-ready, flake-based NixOS configuration template. Stop copy-pasting configs — inherit a curated foundation and override only what your machine needs.
+# A NixOS config you actually want to start from
 
----
+Flake-based, profile-driven, multi-host. Stop copy-pasting configs — inherit a
+curated foundation and override only what your machine needs.
+</div>
 
-## What you get
+<div class="btn-row">
+<a class="btn" href="{{ '/getting-started/' | relative_url }}">get started</a>
+<a class="btn" href="{{ '/usage/' | relative_url }}">the menu</a>
+<a class="btn" href="{{ '/documentation/' | relative_url }}">docs</a>
+<a class="btn" href="https://github.com/olafkfreund/nixos-template">github</a>
+</div>
 
-- **Flake-first** — fully reproducible with `flake.lock`; experimental features enabled out of the box
-- **Profile-based Home Manager** — `base`, `desktop`, `development`, and `server` profiles compose cleanly; no copy-paste between hosts
-- **Multi-host templates** — `desktop-template`, `laptop-template`, `server-template`, `wsl2-template`, `darwin-desktop`, `darwin-laptop`, `darwin-server` ready to clone
-- **GPU auto-detection** — AMD, NVIDIA, and Intel graphics configured declaratively; switch by setting `hardware.gpu.type`
-- **VM testing** — spin up any host config as a QEMU VM in seconds; no install required
-- **WSL2** — build a NixOS WSL2 tarball and import it on Windows with a single command
-- **macOS / nix-darwin** — Darwin host templates for Apple Silicon and Intel Macs; Home Manager included
-- **Agenix secrets** — age-encrypted secrets wired into systemd services; zero plaintext in the Nix store
-- **Custom installer ISOs** — generate bootable NixOS ISOs pre-seeded with your config via `nixos-generators`
-- **Multi-platform deployment images** — produce AMIs, QCOW2, raw, VirtualBox, and more with `just build-images`
+## ▸ see it in action
 
----
+`just` opens a guided control panel — browse, read, pick. It previews the
+command and confirms before running.
 
-## Quick start
+<video src="{{ '/assets/menu/showcase.mp4' | relative_url }}" autoplay loop muted playsinline controls></video>
 
-```bash
-# 1. Clone and enter the dev shell (provides nixpkgs-fmt, statix, deadnix, just, …)
-git clone https://github.com/olafkfreund/nixos-template.git
-cd nixos-template
-nix develop
+![The just menu]({{ '/assets/menu/showcase.gif' | relative_url }})
 
-# 2. Copy the desktop template to your hostname
-cp -r hosts/desktop-template hosts/my-machine
-# Edit hosts/my-machine/configuration.nix and home.nix to taste
+## ▸ what you get
 
-# 3. Generate hardware config on the target machine
-sudo nixos-generate-config --show-hardware-config > hosts/my-machine/hardware-configuration.nix
+<div class="feature-grid">
+<div class="card"><b>Flake-first</b><p>Fully reproducible with flake.lock — one command to build any host.</p></div>
+<div class="card"><b>Profile-based Home Manager</b><p>base · desktop · development · server profiles compose cleanly.</p></div>
+<div class="card"><b>Multi-host templates</b><p>desktop · laptop · server · WSL2 · macOS — ready to clone.</p></div>
+<div class="card"><b>GPU auto-detection</b><p>AMD, NVIDIA, and Intel configured declaratively.</p></div>
+<div class="card"><b>VM testing</b><p>Spin up any host as a QEMU VM in seconds — no install.</p></div>
+<div class="card"><b>Installer ISOs</b><p>Build bootable NixOS installers pre-seeded with your config.</p></div>
+<div class="card"><b>agenix secrets</b><p>age-encrypted secrets wired into systemd — zero plaintext in the store.</p></div>
+<div class="card"><b>The just menu</b><p>A guided, zero-dependency control panel over every task.</p></div>
+</div>
 
-# 4. Register the host in flake.nix (see the existing entries for the pattern),
-#    then build and switch
-just switch my-machine
-```
-
----
-
-## Try it in a VM — no install required
-
-```bash
-# Build and run the desktop-test VM (QEMU)
-nix build .#nixosConfigurations.desktop-test.config.system.build.vm
-./result/bin/run-desktop-test-vm
-# Login: vm-user / nixos
-```
-
-The VM boots with GNOME, all profile packages, and the full Home Manager configuration — a live preview of what you'll get after `nixos-rebuild switch`.
-
----
-
-## Repository
+## ▸ quick start
 
 ```
-$ xdg-open https://github.com/olafkfreund/nixos-template
+$ nix develop                                   # enter the dev shell
+$ cp -r hosts/desktop-template hosts/$(hostname)
+$ sudo nixos-generate-config --show-hardware-config \
+    > hosts/$(hostname)/hardware-configuration.nix
+$ just switch                                    # build & activate
 ```
 
-- [GitHub repository](https://github.com/olafkfreund/nixos-template)
-- [Host templates guide](https://github.com/olafkfreund/nixos-template/blob/main/docs/HOST-TEMPLATES.md)
-- [VM support](https://github.com/olafkfreund/nixos-template/blob/main/docs/VM-SUPPORT.md)
-- [WSL2 configuration](https://github.com/olafkfreund/nixos-template/blob/main/docs/WSL2-CONFIGURATION.md)
-- [macOS / nix-darwin guide](https://github.com/olafkfreund/nixos-template/blob/main/docs/NIX-DARWIN-GUIDE.md)
-- [Agenix secrets](https://github.com/olafkfreund/nixos-template/blob/main/docs/AGENIX-SECRETS.md)
-- [ISO creation](https://github.com/olafkfreund/nixos-template/blob/main/docs/ISO-CREATION.md)
-- [Deployment images](https://github.com/olafkfreund/nixos-template/blob/main/docs/DEPLOYMENT-IMAGES.md)
+Just want to look first? Boot it in a VM, no install:
+
+```
+$ nix build .#nixosConfigurations.desktop-test.config.system.build.vm
+$ ./result/bin/run-desktop-test-vm               # login: vm-user / nixos
+```
+
+## ▸ screenshots
+
+<div class="shot-gallery">
+<figure><a href="{{ '/assets/menu/01-main.png' | relative_url }}"><img src="{{ '/assets/menu/01-main.png' | relative_url }}" alt="Main menu"></a><figcaption>The control panel</figcaption></figure>
+<figure><a href="{{ '/assets/menu/02-build-apply.png' | relative_url }}"><img src="{{ '/assets/menu/02-build-apply.png' | relative_url }}" alt="Build & Apply"></a><figcaption>Build &amp; Apply</figcaption></figure>
+<figure><a href="{{ '/assets/menu/05-installer-isos.png' | relative_url }}"><img src="{{ '/assets/menu/05-installer-isos.png' | relative_url }}" alt="Installer ISOs"></a><figcaption>Installer ISOs</figcaption></figure>
+</div>
+
+<p style="margin-top:1.4rem"><a class="btn" href="{{ '/usage/' | relative_url }}">explore the full menu</a></p>


### PR DESCRIPTION
The prior redesign landed the phosphor CSS but the default.html/index.md rewrites silently failed, so the live site showed the new CSS on the old HTML. This recreates both files so the CRT terminal theme, restructured sidebar, and visual front page actually render.