### PR TITLE
Clear every remaining deprecation warning, across all 23 hosts

### DIFF
--- a/home/common/git.nix
+++ b/home/common/git.nix
@@ -70,15 +70,17 @@
       "*.temp"
       "*.log"
     ];
+  };
 
-    # Delta for better diff viewing
-    delta = {
-      enable = lib.mkDefault true;
-      options = {
-        navigate = true;
-        line-numbers = true;
-        syntax-theme = "Dracula";
-      };
+  # Delta is its own module now; programs.git.delta.* was renamed, and the
+  # automatic git integration is deprecated in favour of setting it explicitly.
+  programs.delta = {
+    enable = lib.mkDefault true;
+    enableGitIntegration = lib.mkDefault true;
+    options = {
+      navigate = true;
+      line-numbers = true;
+      syntax-theme = "Dracula";
     };
   };
 }

--- a/home/profiles/desktop.nix
+++ b/home/profiles/desktop.nix
@@ -137,7 +137,7 @@
     };
 
     # Git configuration for desktop development
-    git.extraConfig = {
+    git.settings = {
       # Enhanced diff and merge tools for GUI environments
       diff.tool = "vscode";
       merge.tool = "vscode";

--- a/home/profiles/development.nix
+++ b/home/profiles/development.nix
@@ -228,7 +228,7 @@
     # Development-focused Git configuration
     git = {
       # mkDefault so host configs can override any individual git setting
-      extraConfig = lib.mkDefault {
+      settings = lib.mkDefault {
         # Enhanced development workflow
         push.default = "current";
         pull.ff = "only";

--- a/home/roles/server-admin.nix
+++ b/home/roles/server-admin.nix
@@ -97,7 +97,7 @@
 
     # Git with server-focused settings
     git = {
-      extraConfig = {
+      settings = {
         core.editor = "vim"; # Vim is more common on servers
         user.useConfigOnly = true; # Require explicit user config
       };

--- a/home/users/developer.nix
+++ b/home/users/developer.nix
@@ -31,10 +31,11 @@
     # Enhanced Git configuration for development
     git = {
       enable = true;
-      settings.user.name = "Developer Name";
-      settings.user.email = "developer@example.com";
 
-      extraConfig = {
+      settings = {
+        user.name = "Developer Name";
+        user.email = "developer@example.com";
+
         init.defaultBranch = "main";
         pull.rebase = true;
         push.autoSetupRemote = true;

--- a/home/users/minimal.nix
+++ b/home/users/minimal.nix
@@ -18,10 +18,11 @@
     # Minimal Git configuration
     git = {
       enable = true;
-      settings.user.name = "Minimal User";
-      settings.user.email = "minimal@example.com";
 
-      extraConfig = {
+      settings = {
+        user.name = "Minimal User";
+        user.email = "minimal@example.com";
+
         init.defaultBranch = "main";
         pull.rebase = true;
         core.editor = "nano";

--- a/home/users/server.nix
+++ b/home/users/server.nix
@@ -23,10 +23,11 @@
     # Server-focused Git configuration
     git = {
       enable = true;
-      settings.user.name = "Server Admin";
-      settings.user.email = "admin@example.com";
 
-      extraConfig = {
+      settings = {
+        user.name = "Server Admin";
+        user.email = "admin@example.com";
+
         init.defaultBranch = "main";
         pull.rebase = true;
         push.autoSetupRemote = true;

--- a/home/users/user.nix
+++ b/home/users/user.nix
@@ -20,10 +20,11 @@
     # Git configuration
     git = {
       enable = true;
-      settings.user.name = "User Name";
-      settings.user.email = "user@example.com";
 
-      extraConfig = {
+      settings = {
+        user.name = "User Name";
+        user.email = "user@example.com";
+
         init.defaultBranch = "main";
         pull.rebase = true;
         push.autoSetupRemote = true;

--- a/hosts/desktop-test/home.nix
+++ b/hosts/desktop-test/home.nix
@@ -99,19 +99,26 @@
   programs.ssh = {
     enable = true;
 
-    extraConfig = ''
-      # VM-friendly SSH settings
-      Host *
-        ServerAliveInterval 60
-        ServerAliveCountMax 3
-        TCPKeepAlive yes
+    # Home Manager's implicit defaults are being removed upstream, so opt out
+    # and state what this VM actually wants.
+    enableDefaultConfig = false;
 
-      # Common VM access patterns
-      Host host hypervisor
-        HostName 10.0.2.2
-        User your-username
-        Port 22
-    '';
+    # `settings` takes upstream OpenSSH directive names; matchBlocks is
+    # deprecated. The attribute name becomes the `Host` line.
+    settings = {
+      "*" = {
+        ServerAliveInterval = 60;
+        ServerAliveCountMax = 3;
+        TCPKeepAlive = "yes";
+      };
+
+      # Reaching the hypervisor from inside a QEMU user-mode network
+      "host hypervisor" = {
+        HostName = "10.0.2.2";
+        User = "your-username";
+        Port = 22;
+      };
+    };
   };
 
   # VM-specific environment variables (extends base profile)

--- a/hosts/laptop-template/configuration.nix
+++ b/hosts/laptop-template/configuration.nix
@@ -90,9 +90,11 @@
 
     # Suspend on low battery
     logind = {
-      powerKey = "suspend";
-      lidSwitch = "suspend";
-      lidSwitchExternalPower = "ignore";
+      settings.Login = {
+        HandlePowerKey = "suspend";
+        HandleLidSwitch = "suspend";
+        HandleLidSwitchExternalPower = "ignore";
+      };
     };
   };
 

--- a/hosts/laptop-template/home.nix
+++ b/hosts/laptop-template/home.nix
@@ -60,8 +60,8 @@
     rclone
 
     # Lightweight alternatives (these live under the xfce package set)
-    xfce.mousepad # Lightweight text editor
-    xfce.thunar # Lightweight file manager
+    mousepad # Lightweight text editor
+    thunar # Lightweight file manager
   ];
 
   # Laptop-optimized bash aliases (extends base profile)
@@ -140,7 +140,7 @@
   '';
 
   # Laptop-optimized Git configuration for mobile work
-  programs.git.extraConfig = {
+  programs.git.settings = {
     # Laptop-specific Git optimizations
     core.preloadindex = true;
     core.fscache = true;

--- a/hosts/wsl2-template/home.nix
+++ b/hosts/wsl2-template/home.nix
@@ -182,7 +182,7 @@
   };
 
   # WSL2-specific Git configuration
-  programs.git.extraConfig = {
+  programs.git.settings = {
     # Windows line ending handling
     core.autocrlf = "input";
     core.eol = "lf";

--- a/modules/hardware/power-management.nix
+++ b/modules/hardware/power-management.nix
@@ -269,11 +269,12 @@ in
 
       # Laptop lid and power button handling
       logind = {
-        lidSwitch = mkIf (cfg.profile == "laptop") cfg.laptop.suspendMethod;
-        lidSwitchExternalPower = mkIf (cfg.profile == "laptop") "ignore";
+
         # `services.logind.extraConfig` was replaced by the structured
         # `services.logind.settings.Login` freeform option.
         settings.Login = mkIf (cfg.profile == "laptop") {
+          HandleLidSwitch = cfg.laptop.suspendMethod;
+          HandleLidSwitchExternalPower = "ignore";
           HandlePowerKey = "suspend";
           HandleSuspendKey = "suspend";
           HandleHibernateKey = "hibernate";

--- a/modules/installer/base.nix
+++ b/modules/installer/base.nix
@@ -37,6 +37,10 @@
     };
   };
 
+  # The installer profile pulls in ZFS. `forceImportRoot = false` becomes the
+  # upstream default in 26.11 and reduces the risk of data loss, so set it now.
+  boot.zfs.forceImportRoot = false;
+
   # Set root password for installer (change this!)
   # Override the default locked password from core/users.nix for installer environments
   users.users.root = {


### PR DESCRIPTION
**Correction to #32.** That PR claimed zero deprecation warnings. I measured it on **one** host (`desktop-template`). A full sweep across all 23 `nixosConfigurations` found **27 warnings** in hosts I hadn't sampled — the macOS VMs and installer ISOs.

Now verified properly: **23 of 23 hosts report zero warnings.**

## Fixed by class

| Deprecation | Replacement |
|---|---|
| `programs.git.extraConfig` | `settings` — in the files earlier passes missed |
| `programs.git.delta.*` | `programs.delta.*`, now its own HM module |
| delta auto git-integration | `enableGitIntegration` set explicitly |
| `services.logind.{lidSwitch,lidSwitchExternalPower,powerKey}` | `settings.Login.Handle*` |
| `pkgs.xfce.{thunar,mousepad}` | top-level `pkgs.thunar` / `pkgs.mousepad` |
| `programs.ssh` implicit defaults | `enableDefaultConfig = false` + explicit values |
| `programs.ssh.matchBlocks` | `programs.ssh.settings`, upstream OpenSSH names |
| `boot.zfs.forceImportRoot` | `false` on installers (the 26.11 default) |

Where a host already had dotted `settings.user.name` next to an `extraConfig` block, the two are **merged into one** `settings` block — a Nix attrset can't hold both `settings = { ... }` and `settings.user.x = ...`.

## One failure worth recording

A regex-based merge matched the **wrong closing brace** and corrupted three files. Caught by parsing every file, reverted with `git checkout`, and redone line-based with no brace matching at all. The line-based version is what's in this PR.

## Verification

- Every one of the 23 hosts evaluated individually: **0 warnings**
- `nix flake check` passes
- Committed **without** `--no-verify` — the unified hooks from #32 work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtPNHNffvjSD3RYJLAk4tL