### PR TITLE
Replace nixos-generators with nixpkgs' own system.build.images

### DIFF
--- a/docs/DEPLOYMENT-IMAGES.md
+++ b/docs/DEPLOYMENT-IMAGES.md
@@ -368,7 +368,7 @@ sudo nix-collect-garbage -d
 ## Additional Resources
 
 - [NixOS Manual](https://nixos.org/manual/nixos/stable/)
-- [nixos-generators Documentation](https://github.com/nix-community/nixos-generators)
+- [NixOS image documentation](https://nixos.org/manual/nixos/stable/#sec-image-nixos-rebuild-build-image) — `system.build.images`, which replaced nixos-generators in NixOS 25.05
 - [NixOS Cloud Images](https://nixos.org/download#cloud-images)
 - [Deployment Best Practices](./ADVANCED-FEATURES.md)
 

--- a/flake.lock
+++ b/flake.lock
@@ -218,42 +218,6 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -314,7 +278,6 @@
         "home-manager": "home-manager_2",
         "niri": "niri",
         "nix-darwin": "nix-darwin",
-        "nixos-generators": "nixos-generators",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -56,10 +56,6 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     # niri has no module in nixpkgs or home-manager, so its config would
     # otherwise have to be a hand-written KDL string. This provides both.
     niri = {
@@ -77,7 +73,6 @@
       treefmt-nix,
       git-hooks,
       nix-darwin,
-      nixos-generators,
       ...
     }@inputs:
     let
@@ -199,12 +194,7 @@
 
       # Import deployment images generator
       deploymentImages = import ./lib/deployment-images.nix {
-        inherit
-          inputs
-          outputs
-          nixpkgs
-          nixos-generators
-          ;
+        inherit inputs outputs nixpkgs;
       };
 
       # Import Darwin configurations generator

--- a/lib/deployment-images.nix
+++ b/lib/deployment-images.nix
@@ -4,11 +4,45 @@
   inputs,
   outputs,
   nixpkgs,
-  nixos-generators,
 }:
 
 let
   inherit (nixpkgs) lib;
+
+  # nixos-generators format names -> the equivalent in nixpkgs' own
+  # `system.build.images`, which replaced it upstream in NixOS 25.05.
+  formatModule = {
+    amazon = "amazon";
+    azure = "azure";
+    do = "digital-ocean";
+    iso = "iso";
+    lxc = "lxc";
+    qcow = "qemu";
+    virtualbox = "virtualbox";
+    vmware = "vmware";
+  };
+
+  # Build one image: evaluate the host, then take the format's output from
+  # `system.build.images`. This is what nixos-generators did, minus the
+  # dependency.
+  #
+  # The per-image settings go into `image.modules.<format>` rather than the base
+  # module list. `system.build.images.<format>` is a separate evaluation built
+  # with extendModules, so options a format declares -- `isoImage.*`, for
+  # instance -- only exist there. `image.modules` is a deferredModule, so this
+  # merges with the format module nixpkgs already puts there.
+  mkImage =
+    baseConfig: config:
+    let
+      fmt = formatModule.${config.format} or (throw "unknown image format: ${config.format}");
+      evaluated = nixpkgs.lib.nixosSystem (
+        baseConfig
+        // {
+          modules = baseConfig.modules ++ [ { image.modules.${fmt} = config.extraConfig; } ];
+        }
+      );
+    in
+    evaluated.config.system.build.images.${fmt};
 
   # Factory function to create deployment images
   mkDeploymentImages =
@@ -144,7 +178,11 @@ let
         lxc = {
           format = "lxc";
           extraConfig = {
-            # LXC container optimizations
+            # LXC container optimizations. modules/core/boot.nix turns on
+            # systemd-boot for every host; a container has no bootloader, and
+            # leaving both it and the container's init script enabled defines
+            # system.build.installBootLoader twice.
+            boot.loader.systemd-boot.enable = lib.mkForce false;
             boot.isContainer = true;
             services.openssh.enable = true;
             security.audit.enable = lib.mkForce false;
@@ -384,32 +422,10 @@ let
       };
 
       # Generate standard platform images
-      standardImages = lib.mapAttrs (
-        _name: config:
-        nixos-generators.nixosGenerate (
-          baseConfig
-          // {
-            inherit (config) format;
-            modules = baseConfig.modules ++ [
-              (_: config.extraConfig)
-            ];
-          }
-        )
-      ) platformConfigs;
+      standardImages = lib.mapAttrs (_name: mkImage baseConfig) platformConfigs;
 
       # Generate specialized images
-      specialImages = lib.mapAttrs (
-        _name: config:
-        nixos-generators.nixosGenerate (
-          baseConfig
-          // {
-            inherit (config) format;
-            modules = baseConfig.modules ++ [
-              (_: config.extraConfig)
-            ];
-          }
-        )
-      ) specializedImages;
+      specialImages = lib.mapAttrs (_name: mkImage baseConfig) specializedImages;
 
     in
     standardImages

--- a/site/features.md
+++ b/site/features.md
@@ -100,7 +100,7 @@ Full reference: [Agenix secrets](https://github.com/olafkfreund/nixos-template/b
 
 ## Custom Installer ISOs
 
-Generate a bootable NixOS ISO pre-seeded with your configuration using `nixos-generators`. Boot from a USB stick to install your exact setup on bare metal.
+Generate a bootable NixOS ISO pre-seeded with your configuration using nixpkgs' own `system.build.images`. Boot from a USB stick to install your exact setup on bare metal.
 
 ```bash
 # Build the installer ISO for the default installer profile
@@ -117,7 +117,7 @@ Full reference: [ISO creation](https://github.com/olafkfreund/nixos-template/blo
 
 ## Multi-platform Deployment Images
 
-Produce cloud and hypervisor images from the same configuration used on bare metal. The `build-images` targets call `nixos-generators` with appropriate format flags.
+Produce cloud and hypervisor images from the same configuration used on bare metal. The `build-images` targets read `system.build.images.<format>` straight from nixpkgs, so there is no extra flake input to keep in step.
 
 ```bash
 just build-images


### PR DESCRIPTION
The last item on the review list. `nixos-generators` has been deprecated since **NixOS 25.05**, when image building was upstreamed into nixpkgs — it printed a deprecation notice on every evaluation of the packages output and pulled in its own `nixpkgs` and `nixlib`.

## What changed

`lib/deployment-images.nix` now evaluates each host with `nixpkgs.lib.nixosSystem` and reads `system.build.images.<format>`.

| ours | upstream |
|---|---|
| `amazon` `azure` `iso` `lxc` `virtualbox` `vmware` | same |
| `do` | `digital-ocean` |
| `qcow` | `qemu` |

**Nothing is lost.** All 12 package outputs keep their names and all 12 still instantiate.

## Two things that had to change

**Per-image settings moved to `image.modules.<format>`.** `system.build.images.<format>` is a *separate* evaluation built with `extendModules`, so options a format declares only exist there — setting `isoImage.makeEfiBootable` in the base config failed with *"the option isoImage does not exist"*. `image.modules` is a `deferredModule`, so this **merges** with the format module nixpkgs already places there rather than replacing it.

**LXC needed `boot.loader.systemd-boot.enable = mkForce false`.** `modules/core/boot.nix` enables systemd-boot for every host, and a container also gets a boot loader from `lxc-container.nix` — defining `system.build.installBootLoader` twice. nixos-generators never surfaced this because its container format replaced the whole module set.

## Verification

- **All 12 images instantiate** (`iso qemu aws azure digitalocean lxc vmware virtualbox-desktop production-server development-vm development-minimal nixos-vm-builder-docker`)
- `nix flake check` passes · treefmt clean
- Evaluating the packages output no longer prints a deprecation warning

Docs updated: `DEPLOYMENT-IMAGES.md` links the NixOS image manual; `site/features.md` no longer claims the images come from nixos-generators.

## Flake inputs after this

`agenix`, `git-hooks`, `home-manager`, `niri`, `nix-darwin`, `nixos-wsl`, `nixpkgs`, `treefmt-nix` — **eight**, down from ten at the start of the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtPNHNffvjSD3RYJLAk4tL