### PR TITLE
Bring the docs and site in line with what the template now is

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A modular, flake-based NixOS starter template with Home Manager integration, multi-host support, automatic GPU driver detection, and ready-made configurations for desktops, laptops, servers, virtual machines, WSL2, and macOS (nix-darwin). Clone it, copy a host template, and you have a working declarative system configuration in minutes.
 
+**Wayland-only, three desktops:** GNOME, [Hyprland](https://hypr.land) and [niri](https://github.com/YaLTeR/niri). There is no X11 session — XWayland is enabled so Steam, Discord and older Electron apps still run. Hyprland and niri are configured through Home Manager, so a host can override a single keybinding without replacing the whole config file.
+
 ---
 
 ## Quick Start (NixOS)

--- a/docs/ADVANCED-FEATURES.md
+++ b/docs/ADVANCED-FEATURES.md
@@ -9,7 +9,7 @@ The template now includes several advanced modules that provide enterprise-grade
 - **Advanced Hardware Detection** - Automatic hardware profiling and optimization
 - **Performance Monitoring** - Comprehensive system monitoring with Prometheus and Grafana
 - **Enhanced Nix Optimization** - Advanced Nix store management and build optimization
-- **Secrets Management** - SOPS-nix integration for secure configuration management
+- **Secrets Management** - agenix integration for age-encrypted secrets
 - **Comprehensive Testing** - VM-based integration testing and validation
 - **Module Template** - Production-ready module development patterns
 
@@ -136,14 +136,13 @@ modules.core.nixOptimization = {
 - Experimental features management
 - Resource limits for build isolation
 
-### 🔐 Secrets Management (SOPS-nix Integration)
+### 🔐 Secrets Management (agenix)
 
-Secure configuration management with age encryption:
+Secrets are age-encrypted in the repository and decrypted to tmpfs at boot,
+never into the Nix store.
 
 ```nix
-# In your configuration. This template uses agenix, not sops-nix:
-# secrets are age-encrypted in the repository and decrypted to tmpfs at
-# boot, never into the Nix store.
+# In your configuration
 age.secrets."database/password" = {
   file = ./secrets/database-password.age;
   owner = "postgres";
@@ -351,7 +350,7 @@ The system automatically detects and applies performance profiles:
 ### Security
 
 - Enable AppArmor and fail2ban for enhanced security
-- Use SOPS for secrets management
+- Use agenix for secrets management
 - Regular security updates through automated testing
 - Network segmentation and firewall rules
 

--- a/site/index.md
+++ b/site/index.md
@@ -39,12 +39,13 @@ command and confirms before running.
 ## ▸ what you get
 
 <div class="feature-grid">
+<div class="card"><b>Wayland-only</b><p>GNOME · Hyprland · niri. No X11 session; XWayland keeps legacy apps working.</p></div>
 <div class="card"><b>Flake-first</b><p>Fully reproducible with flake.lock — one command to build any host.</p></div>
 <div class="card"><b>Profile-based Home Manager</b><p>base · desktop · development · server profiles compose cleanly.</p></div>
 <div class="card"><b>Multi-host templates</b><p>desktop · laptop · server · WSL2 · macOS — ready to clone.</p></div>
 <div class="card"><b>GPU auto-detection</b><p>AMD, NVIDIA, and Intel configured declaratively.</p></div>
 <div class="card"><b>VM testing</b><p>Spin up any host as a QEMU VM in seconds — no install.</p></div>
-<div class="card"><b>Installer ISOs</b><p>Build bootable NixOS installers pre-seeded with your config.</p></div>
+<div class="card"><b>Installer &amp; cloud images</b><p>ISO, qcow2, AWS, Azure, DigitalOcean, LXC, VMware — from nixpkgs directly.</p></div>
 <div class="card"><b>agenix secrets</b><p>age-encrypted secrets wired into systemd — zero plaintext in the store.</p></div>
 <div class="card"><b>The just menu</b><p>A guided, zero-dependency control panel over every task.</p></div>
 </div>


### PR DESCRIPTION
An audit of every doc claim against the merged code. Most already held; **three did not**.

## Fixed

**`docs/ADVANCED-FEATURES.md`** advertised *"SOPS-nix integration for secure configuration management"* in its feature list and as a section heading — while the body underneath had already been rewritten to agenix. The `sops-nix` input was removed several commits ago, so the headline promised something the flake no longer ships.

**`README.md` never said which desktops the template provides.** A gap before, a real omission now that Wayland-only is a defining choice rather than an implementation detail — someone evaluating the template shouldn't have to read `modules/desktop/` to discover there's no X11 session. Now names GNOME, Hyprland and niri, notes XWayland is on so Steam and older Electron apps still work, and that the tiling compositors are configured through Home Manager.

**`site/index.md`'s feature grid** predated both the desktop work and the image refactor. Gains a Wayland-only card; "Installer ISOs" becomes "Installer & cloud images" listing what actually builds — ISO, qcow2, AWS, Azure, DigitalOcean, LXC, VMware — from nixpkgs directly.

## Checked and deliberately left alone

`site/showcase.md` claims *every snippet on it is copied from the repository*, so each was re-verified against source: the `shellAliases` `mkDefault` in `home/profiles/base.nix`, `useGlobalPkgs` in `lib/flake-utils.nix`, the agenix module in `mkSystem`, the nvidia driver enum, the agenix `secretsPath` default, and the checks block — which still lists exactly the nine checks the flake exposes.

The README project-structure diagram matches `lib/` as it stands. `virt-manager` in `NON-NIXOS-USAGE.md` is an apt/dnf/pacman package name, not the deleted module. The `mkHost` and `modules/profiles` mentions in `HOST-TEMPLATES.md` and `NIXOS-ANTI-PATTERNS.md` are deliberate historical notes explaining what was removed and why.

## Verification

`nix flake check` passes · treefmt clean · Jekyll builds **35 pages, 0 broken internal links** · claimed image formats verified against `nix eval` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtPNHNffvjSD3RYJLAk4tL